### PR TITLE
chg: minor tidying around the place:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,29 @@
 # limesurveyrc2parser
 Parser for the LimeSurvey Remote Control API version 2.0
 
+
+## What Is It?
+This library parses the LimeSurvey RC2 API PHP source code and extracts
+the method names, arguments, argument types, docstrings and such to generate 
+a Python wrapper client. Magical! :tada:
+
+The template for generating Python methods and overall structure is based on 
+another client, [LimeSurveyRC2API](https://github.com/lindsay-stevens/limesurveyrc2api). 
+In comparison, the advantages of the generated client are that it'll have 
+methods for available API endpoints, and by generating them it makes it easy to 
+keep up to date with changes in the API. Disadvantages are that it won't have 
+the error message detection stuff or integration tests - but maybe these could 
+be new features of this library! (Open a PR! :thumbsup:).
+
+
 ## Usage
 After installation, just run
 * `lsrc2download` (download the PHP source code to 
    the current dir)
 * `lsrc2generatepy` (reads the downloaded PHP source code
    and generates a `lsrc2client.py` file)
+
+Or if you're using the repo without an install: `python script.py --download --generate`
 
 Now, you are ready to go:
 ```
@@ -20,6 +37,7 @@ Python 3.6.2 (v3.6.2:5fd33b5, Jul  8 2017, 04:14:34) [MSC v.1900 32 bit (Intel)]
 {'status': 'No surveys found'}
 ```
 
+
 ## Credentials
 The template for generating the python client code is based on the LS RC2 API 
-client by Lindsay Stevens[https://github.com/lindsay-stevens/limesurveyrc2api](https://github.com/lindsay-stevens/limesurveyrc2api)
+client by Lindsay Stevens [https://github.com/lindsay-stevens/limesurveyrc2api](https://github.com/lindsay-stevens/limesurveyrc2api)

--- a/script.py
+++ b/script.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-import requests
+from urllib.request import urlopen
 import limesurveyrc2parser as pkg
+import argparse
 
 
 def download():
@@ -8,12 +9,10 @@ def download():
     url = "https://raw.githubusercontent.com/LimeSurvey/LimeSurvey/master/" \
           "application/helpers/remotecontrol/remotecontrol_handle.php"
     print("Download from %s" % url)
-    r = requests.get(url)
-
-    print("Save as lsrc2source.php")
-    with open('lsrc2source.php', mode='w') as f:
-        f.write(r.text)
-    print("Done")
+    with urlopen(url) as response, open('lsrc2source.php', mode='w') as f:
+        print("Save as lsrc2source.php")
+        f.write(response.read().decode("utf-8"))
+        print("Done")
 
 
 def generate_python_code():
@@ -29,3 +28,18 @@ def generate_python_code():
     with open('lsrc2client.py', mode='w') as f:
         f.write(py_source)
     print("Done")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="""LimeSurvey RC2 API Client Generator""")
+    parser.add_argument("--download", action="store_true", default=False)
+    parser.add_argument("--generate", action="store_true", default=False)
+    args = parser.parse_args()
+    if args.download:
+        download()
+    if args.generate:
+        generate_python_code()
+    if not args.download and not args.generate:
+        print("\nChoose a mode: '--download' and/or '--generate'."
+              " Or just '--help'.\n")

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,7 @@ setup(
     test_suite="tests",
     include_package_data=True,
     license="Apache",
-    install_requires=[
-        "requests",
-        "pydash"
-    ],
+    install_requires=[],
     entry_points={
         "console_scripts": [
             "lsrc2download=script:download",

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,7 +1,0 @@
-import os
-import sys
-
-sys.path.insert(0,
-                os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-import limesurveyrc2parser

--- a/tests/test_php_parser.py
+++ b/tests/test_php_parser.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
-import json
-from .context import limesurveyrc2parser as pkg
-
-Parser = pkg.LimeSurveyRc2PhpSourceParser
+from unittest import TestCase
+from limesurveyrc2parser import LimeSurveyRc2PhpSourceParser as Parser
 
 
-class TestPhpParser(object):
+class TestPhpParser(TestCase):
 
     def test_match_php_function_re_array_default(self):
         """

--- a/tests/test_python_generator.py
+++ b/tests/test_python_generator.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-from .context import limesurveyrc2parser as pkg
+from unittest import TestCase
+from limesurveyrc2parser import LimeSurveyRc2PythonSourceGenerator as \
+    SourceGenerator, LimeSurveyRc2PhpSourceParser as Parser
 
-SourceGenerator = pkg.LimeSurveyRc2PythonSourceGenerator
 
-
-class TestPythonGenerate(object):
+class TestPythonGenerate(TestCase):
     def test_generate(self):
         parse_result = [
             {"name": "function_name",
@@ -19,7 +19,7 @@ class TestPythonGenerate(object):
     def test_generate_real(self):
         with open('resource/lsrc2source.php') as f:
             php_source = f.read()
-        parse_result = pkg.LimeSurveyRc2PhpSourceParser.parse(php_source)
+        parse_result = Parser.parse(php_source)
         py_source = SourceGenerator.generate(parse_result)
         print(py_source)
 


### PR DESCRIPTION
- replace package dependencies with standard lib alternatives
- fix broken test: test_extract_parameter_array_default
- simplify php_default_map lookup
- make test classes subclass unittest.TestCase so that they're picked up
  by test runner (`python setup.py tests` or
  `python -m unittest discover`)
- fix space in readme, add CLI description, add library description
- add a basic CLI for usage without install
- remove deps from setup.py